### PR TITLE
Change 'id' types to String

### DIFF
--- a/definitions/TagGroup/com.adlinktech.vision.inference/2.000/DetectionBoxTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.vision.inference/2.000/DetectionBoxTagGroup.json
@@ -35,14 +35,14 @@
             {
                 "name":"tracker_obj_id",
                 "description":"Detected object id",
-                "kind":"INT64",
+                "kind":"STRING",
 		"optional":true,
                 "unit":"UUID"
             },
             {
                 "name":"category_id",
                 "description":"Detected object cateogry/class ID",
-                "kind":"INT64",
+                "kind":"STRING",
                 "unit":"n/a"
             },
             {


### PR DESCRIPTION
Although we have chosen INT64 to represent tracker-object and category id's, neither Nvidia DeepStream nor OpenVINO/DeepLearningStreamer use this representation in their respective tracker libraries and API's:

DeepStream: https://docs.nvidia.com/metropolis/deepstream/5.0/dev-guide/DeepStream_Development_Guide/baggage/struct__NvDsObjectMeta.html#a05c043991bdf68a50e1844ae92283337
DLS: https://openvinotoolkit.github.io/dlstreamer_gst/classgstgva_1_1tensor_1_1Tensor.html#a0dc226fb3bbd4ae76d33f1e736d87f03

We propose using STRING type instead to promote explicit conversion from/to these frameworks and others in future. Furthermore, we should standardise an id representation for 'untracked' objects within VisionDataModels.